### PR TITLE
Better timeout

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -123,3 +123,8 @@ In this case you can use locks:
        assert my_fixture == "XXX"
 
 In the above example it's important to put the `lock` fixture on the far left-hand side to ensures mutual exclusivity.
+
+Timeouts
+--------
+
+Tests are automatically cancelled after a timeout of 120s. You can change this with the `--asyncio-task-timeout` option.

--- a/pytest_asyncio_cooperative/plugin.py
+++ b/pytest_asyncio_cooperative/plugin.py
@@ -253,7 +253,7 @@ def pytest_runtestloop(session):
                 item = item_by_coro[get_coro(task)]
                 if task_timeout < now - item.enqueue_time:
                     if sys_version_info >= (3, 9):
-                        msg = "Test took too long ({} s)".format(
+                        msg = "Test took too long ({:.2f} s)".format(
                             now - item.enqueue_time
                         )
                         task.cancel(msg=msg)

--- a/tests/test_fail.py
+++ b/tests/test_fail.py
@@ -37,3 +37,27 @@ def test_function_must_be_async(testdir):
     assert includes_lines(expected_lines, result.stdout.lines)
 
     result.assert_outcomes(failed=1)
+
+def test_function_takes_too_long(testdir):
+    testdir.makeconftest(
+        """""")
+
+    testdir.makepyfile(
+        """
+        import asyncio
+        import pytest
+
+
+        @pytest.mark.asyncio_cooperative
+        async def test_a():
+            await asyncio.sleep(2)
+        
+        @pytest.mark.asyncio_cooperative
+        async def test_b():
+            await asyncio.sleep(1.1)
+    """
+    )
+
+    result = testdir.runpytest("--asyncio-task-timeout", "1")
+
+    result.assert_outcomes(failed=1, passed=1)

--- a/tests/test_fail.py
+++ b/tests/test_fail.py
@@ -1,5 +1,7 @@
 from typing import List
 
+import pytest
+
 
 def includes_lines(expected_lines: List[str], lines: List[str]) -> bool:
     for line in lines:
@@ -38,7 +40,11 @@ def test_function_must_be_async(testdir):
 
     result.assert_outcomes(failed=1)
 
-def test_function_takes_too_long(testdir):
+@pytest.mark.parametrize("dur1, dur2, expectedfails, expectedpasses", [
+    (1.1, 2, 2, 0),
+    (2, 2, 2, 0),
+])
+def test_function_takes_too_long(testdir, dur1, dur2, expectedfails, expectedpasses):
     testdir.makeconftest(
         """""")
 
@@ -50,14 +56,14 @@ def test_function_takes_too_long(testdir):
 
         @pytest.mark.asyncio_cooperative
         async def test_a():
-            await asyncio.sleep(2)
+            await asyncio.sleep({})
         
         @pytest.mark.asyncio_cooperative
         async def test_b():
-            await asyncio.sleep(1.1)
-    """
+            await asyncio.sleep({})
+    """.format(dur1, dur2)
     )
 
     result = testdir.runpytest("--asyncio-task-timeout", "1")
 
-    result.assert_outcomes(failed=1, passed=1)
+    result.assert_outcomes(failed=expectedfails, passed=expectedpasses)


### PR DESCRIPTION
More predictable and accurate behaviour of `--asyncio-task-timeout` option.
Documentation for `--asyncio-task-timeout` option.
Unit test for `--asyncio-task-timeout`.
Better error message for tests that get timed out (only when running on >=python3.9).
Fix a warning coming from `asyncio.wait`.
Use `Task.get_coro()` instead of `Task._coro` when available (>=python3.8).
