### PR TITLE
Fix durations in generated junitxml

### DIFF
--- a/pytest_asyncio_cooperative/plugin.py
+++ b/pytest_asyncio_cooperative/plugin.py
@@ -44,16 +44,19 @@ def pytest_runtest_makereport(item, call):
         if hasattr(item, "start") and hasattr(item, "stop"):
             call.start = item.start
             call.stop = item.stop
+            call.duration = call.stop - call.start
 
     elif call.when == "setup":
         if hasattr(item, "start_setup") and hasattr(item, "stop_setup"):
             call.start = item.start_setup
             call.stop = item.stop_setup
+            call.duration = call.stop - call.start
 
     elif call.when == "teardown":
         if hasattr(item, "start_teardown") and hasattr(item, "stop_teardown"):
             call.start = item.start_teardown
             call.stop = item.stop_teardown
+            call.duration = call.stop - call.start
 
 
 def not_coroutine_failure(function_name: str, *args, **kwargs):

--- a/tests/test_junitxml.py
+++ b/tests/test_junitxml.py
@@ -1,0 +1,28 @@
+import re
+
+
+def test_timing_in_junitxml(pytester):
+    pytester.makeconftest("""""")
+
+    pytester.makepyfile(
+        """
+        import asyncio
+        import pytest
+
+
+        @pytest.mark.asyncio_cooperative
+        async def test_a():
+            await asyncio.sleep(1)
+    """
+    )
+
+    result = pytester.runpytest("--junitxml=junit.xml")
+
+    result.assert_outcomes(passed=1)
+
+    found = False
+    with (pytester.path / "junit.xml").open() as f:
+        for match in re.finditer(r'time="([\d.]+)"', f.read()):
+            assert float(match[1]) > 0.7
+            found = True
+    assert found


### PR DESCRIPTION
When calling pytest with `--junitxml=junit.xml`, the generated `junit.xml` contains incorrect durations for all the tests.
The durations are all practically 0. This is in spite of the report on stdout giving correct durations.

I found that the junit plugin uses the `duration` attribute, while the stdout report uses `start` and `stop`.
We already have a hook that overwrites `start` and `stop`.

This PR adds an overwrite to `duration`, thus fixing the problem.
It also includes a new unit-test to verify that the duration in the xml file is correct.