### PR TITLE
use collections.abc instead of collections

### DIFF
--- a/pytest_asyncio_cooperative/plugin.py
+++ b/pytest_asyncio_cooperative/plugin.py
@@ -1,5 +1,5 @@
 import asyncio
-import collections
+import collections.abc
 import functools
 import inspect
 import time
@@ -82,7 +82,7 @@ async def test_wrapper(item):
     async def do_teardowns():
         item.start_teardown = time.time()
         for teardown in teardowns:
-            if isinstance(teardown, collections.Iterator):
+            if isinstance(teardown, collections.abc.Iterator):
                 try:
                     teardown.__next__()
                 except StopIteration:


### PR DESCRIPTION
>DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working.

see https://github.com/python/cpython/commit/c66f9f8d3909f588c251957d499599a1680e2320 .
