### PR TITLE
Support `pytest_asyncio_cooperative`-marked synchronous tests

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -91,3 +91,32 @@ def test_synchronous_tests_run_if_async_tests_fail(testdir):
 
     # we expect this:
     result.assert_outcomes(failed=1, passed=1)
+
+
+def test_synchronous_test_with_async_fixture(testdir):
+    testdir.makepyfile(
+        """
+        import asyncio
+        import pytest
+
+
+        @pytest.fixture
+        async def async_fixture():
+            return await asyncio.sleep(1, 42)
+
+        @pytest.fixture
+        def sync_fixture():
+            return 42
+
+        @pytest.mark.asyncio_cooperative
+        async def test_async(async_fixture, sync_fixture):
+            assert async_fixture == sync_fixture == 42
+
+        @pytest.mark.asyncio_cooperative
+        def test_sync(async_fixture, sync_fixture):
+            assert async_fixture == sync_fixture == 42
+    """
+    )
+
+    result = testdir.runpytest()
+    result.assert_outcomes(passed=2)

--- a/tests/test_fail.py
+++ b/tests/test_fail.py
@@ -1,34 +1,5 @@
 import pytest
 
-from .conftest import includes_lines
-
-
-def test_function_must_be_async(testdir):
-    testdir.makeconftest("""""")
-
-    testdir.makepyfile(
-        """
-        import asyncio
-        import pytest
-
-
-        @pytest.mark.asyncio_cooperative
-        def test_a():
-            assert 1 == 1
-    """
-    )
-
-    expected_lines = [
-        "E       Exception: Function test_a is not a coroutine.",
-        "E       Tests with the `@pytest.mark.asyncio_cooperative` mark MUST be coroutines.",
-        "E       Please add the `async` keyword to the test function.",
-    ]
-
-    result = testdir.runpytest()
-    assert includes_lines(expected_lines, result.stdout.lines)
-
-    result.assert_outcomes(failed=1)
-
 
 @pytest.mark.parametrize("dur1, dur2, expectedfails, expectedpasses", [
     (1.1, 2, 2, 0),


### PR DESCRIPTION
As a suggestion, allow synchronous (i.e., plain `def`) tests to be marked with `pytest.mark.pytest_asyncio_cooperative` and handled by this plugin.

The main use case for this change is to support synchronous tests that depend on one or more async fixtures (as of now, such synchronous tests have to be changed into `async def` coroutines even if they don't use any async functionality).
