### PR TITLE
Bugfix/python37 fstring syntax

### DIFF
--- a/tests/test_fixture.py
+++ b/tests/test_fixture.py
@@ -474,7 +474,7 @@ def test_shared_fixture_caching(testdir, scope, def_, ret, fail):
         import time
 
         called = False
-        @pytest.fixture({scope=})
+        @pytest.fixture(scope={scope})
         {def_} shared_fixture():
             global called
             if called:


### PR DESCRIPTION
Fix fstring syntax in `test_shared_fixture_caching` causing one of the Python3.7 CI failures in https://github.com/willemt/pytest-asyncio-cooperative/pull/54