### PR TITLE
fix: get fixture from conftest closest to the test file

### DIFF
--- a/pytest_asyncio_cooperative/fixtures.py
+++ b/pytest_asyncio_cooperative/fixtures.py
@@ -33,9 +33,9 @@ def _get_fixture(item, arg_name, fixture=None):
 
     _fixtureinfo = item._fixtureinfo
     fixtures = sorted(
-        _fixtureinfo.name2fixturedefs[arg_name], key=lambda x: not x.has_location
+        _fixtureinfo.name2fixturedefs[arg_name], key=lambda x: x.has_location
     )
-    return fixtures[0]
+    return fixtures[-1]
 
 
 async def fill_fixtures(item):

--- a/tests/test_fixture.py
+++ b/tests/test_fixture.py
@@ -502,3 +502,40 @@ def test_shared_fixture_caching(testdir, scope, def_, ret, fail):
         # https://github.com/willemt/pytest-asyncio-cooperative/issues/42
     else:
         result.assert_outcomes(passed=2)
+
+
+def test_getting_fixture_from_closest_conftest(testdir):
+    testdir.makepyfile(
+        **{
+            "conftest": """
+           import pytest
+
+           @pytest.fixture
+           def some_fixture():
+               return "foo"
+            """,
+            "bar/conftest": """
+            import pytest
+
+           @pytest.fixture
+           def some_fixture():
+               return "bar"
+            """,
+            "test_foo": """
+            import pytest
+
+            @pytest.mark.asyncio_cooperative
+            def test_foo(some_fixture):
+                assert some_fixture == "foo"
+            """,
+            "bar/test_bar": """
+            import pytest
+
+            @pytest.mark.asyncio_cooperative
+            def test_bar(some_fixture):
+                assert some_fixture == "bar"
+            """,
+        }
+    )
+    result = testdir.runpytest()
+    result.assert_outcomes(passed=2)


### PR DESCRIPTION
Fix for the issue: https://github.com/willemt/pytest-asyncio-cooperative/issues/60