### PR TITLE
Increase default asyncio_task_timeout to 600

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -127,7 +127,7 @@ In the above example it's important to put the `lock` fixture on the far left-ha
 Timeouts
 --------
 
-Tests are automatically cancelled after a timeout of 120s. You can change this with the `--asyncio-task-timeout` option or by adding an `asyncio_task_timeout` entry to your `pytest.ini` file.
+Tests are automatically cancelled after a timeout of 600s. You can change this with the `--asyncio-task-timeout` option or by adding an `asyncio_task_timeout` entry to your `pytest.ini` file.
 
 Maximum Asynchronous Tasks
 --------------------------

--- a/pytest_asyncio_cooperative/plugin.py
+++ b/pytest_asyncio_cooperative/plugin.py
@@ -36,7 +36,7 @@ def pytest_addoption(parser):
     parser.addini(
         "asyncio_task_timeout",
         "asyncio: number of seconds before a test will be cancelled (int)",
-        default=120,
+        default=600,
     )
 
 


### PR DESCRIPTION
Would you be okay with accepting this change? IMHO, the main reason to use `pytest-asyncio-cooperative` is because your individual tests take too long to run, so a default timeout of 120 seconds seems to be on the short end and causes a lot of my test cases to time out. I'm obviously aware that you can configure a different timeout, but 600 seconds (I'd also be okay with a different value or no timeout as the default) seems like a more sensible default to me.