### PR TITLE
Rerun tests mid-run on another thread for supporting retry libraries

### DIFF
--- a/pytest_asyncio_cooperative/plugin.py
+++ b/pytest_asyncio_cooperative/plugin.py
@@ -304,10 +304,17 @@ def pytest_runtestloop(session):
                         result = None
                         def run_in_thread():
                             nonlocal result
-                            result = asyncio.run(new_task)
+                            try:
+                                result = asyncio.run(new_task)
+                            except Exception as e:
+                                result = e
                         thread = threading.Thread(target=run_in_thread)
                         thread.start()
                         thread.join()
+
+                        if isinstance(result, Exception):
+                            raise result # type: ignore
+
                         return result
 
                     item.runtest = sync_wrapper


### PR DESCRIPTION
Fixes #65 

I tried A LOT of options before resorting to starting a new thread, but since we can't have nested event loops and we do need to return synchronously in here, didn't find a better option