### PR TITLE
Handle kwargs in cached function fixtures

### DIFF
--- a/tests/test_fixture.py
+++ b/tests/test_fixture.py
@@ -539,3 +539,30 @@ def test_getting_fixture_from_closest_conftest(testdir):
     )
     result = testdir.runpytest()
     result.assert_outcomes(passed=2)
+
+
+def test_fixture_nested_exception(testdir):
+    testdir.makepyfile(
+        f"""
+        import pytest
+
+
+        @pytest.fixture(scope="module")
+        async def first():
+            return "first"
+
+
+        @pytest.fixture(scope="module")
+        async def second(first):
+            assert False
+            yield first
+
+
+        @pytest.mark.asyncio_cooperative
+        async def test_hello(second):
+            print("hello")
+        """
+    )
+
+    result = testdir.runpytest()
+    result.assert_outcomes(errors=0, failed=1)


### PR DESCRIPTION
Fixes #31. This is mostly a cherry-pick of @kstech-roadie's https://github.com/willemt/pytest-asyncio-cooperative/commit/5d0c7ab8838ccd558eaf0660574b02774a7f3ed3, with one additional callsite fixed and a comment added about kwargs support for caching.