### PR TITLE
use asyncio.run() and catch keyboard interrupt

### DIFF
--- a/pytest_asyncio_cooperative/plugin.py
+++ b/pytest_asyncio_cooperative/plugin.py
@@ -167,12 +167,11 @@ def _run_test_loop(tasks, session, run_tests):
         or session.config.getini("max_asyncio_tasks")
     )
 
-    loop = asyncio.new_event_loop()
+    task = run_tests(tasks, int(max_tasks))
     try:
-        task = run_tests(tasks, int(max_tasks))
-        loop.run_until_complete(task)
-    finally:
-        loop.close()
+        asyncio.run(task)
+    except KeyboardInterrupt:
+        pass
 
 
 @pytest.hookimpl(hookwrapper=True, tryfirst=True)


### PR DESCRIPTION
I was having some issues where a keyboard interrupt would cause the main loop to close without cancelling its tasks. This means that the cleanup code that I had in my fixtures was never being run. This pull request uses asyncio.run() to handle cancelling of tasks on a keyboard interrupt gracefully.